### PR TITLE
Revise AI tool usage policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ You must adheres to the [Contributor Covenant](https://github.com/OpenDroneMap/d
 
 ## Use of AI
 
-Use of AI tools to increase productivity and facilitate contributions is generally discouraged. Prompt driven pull requests are not allowed. Limited, responsible assistive use may be acceptable but requires disclosure and discussion.
+Responsible use of AI tools to increase productivity and facilitate contributions is generally allowed, as long as contributions are carefully reviewed and tested by the contributor, that no copyright is being infringed and that each contribution generated partially or fully using AI clearly states so.
 
 ## Scope
 


### PR DESCRIPTION
The current policy is not sensible. E.g. https://github.com/OpenDroneMap/WebODM/pull/1820

These tools are changing the field and we're turning away good contributions.

I propose to change the stance on AI usage.